### PR TITLE
Update to regex match for both htm and html extensions

### DIFF
--- a/scripts/run.js
+++ b/scripts/run.js
@@ -71,7 +71,7 @@
       }
 
       // format the code
-      if (source.match(".html" + "$") == ".html") {
+      if (source.match(".html?" + "$")) {
         log(style_html(data, option));
       }
       else if (source.match(".css" + "$") == ".css") {


### PR DESCRIPTION
I was editing a document with extension "htm" and was wondering why the plugin did not seem to work. Making the small change to the regex seems to have resolved that for me.
