### PR TITLE
Windows not compatible with .NamedTemporaryFile() without (delete=False) passed in.

### DIFF
--- a/HTMLPrettify.py
+++ b/HTMLPrettify.py
@@ -33,7 +33,7 @@ following the instructions at:\n"""
     bufferText = self.view.substr(sublime.Region(0, self.view.size()))
     # ...and save it in a temporary file. This allows for scratch buffers
     # and dirty files to be beautified as well.
-    namedTempFile = tempfile.NamedTemporaryFile()
+    namedTempFile = tempfile.NamedTemporaryFile(delete=False)
     tempPath = namedTempFile.name
     print("Saving buffer to: " + tempPath)
     f = codecs.open(tempPath, mode='w', encoding='utf-8')


### PR DESCRIPTION
...File

Windows will close the file before it can be re-opened due to the use of O_TEMPORARY in the file creation flags. Therefore sublime throws error. Adding delete=False fixes but will not automatically clean up the temp files so user will need to manually delete temp files with this fix. Not ideal. resolves #45
