### PR TITLE
Added newline at eof if respective Sublime settings is true

### DIFF
--- a/HTMLPrettify.py
+++ b/HTMLPrettify.py
@@ -88,6 +88,10 @@ following the instructions at:\n"""
     if len(output) > 0:
       region = sublime.Region(0, self.view.size())
       text = output.decode("utf-8")
+      
+      if self.view.settings().get("ensure_newline_at_eof_on_save") and not text.endswith("\n"):
+        text += "\n"
+        
       self.view.replace(edit, region, text)
 
 class PreSaveFormatListner(sublime_plugin.EventListener):


### PR DESCRIPTION
We found a bug where the EOF Sublime setting was not being respected, on save the EOF newline was being removed, and fixed by appending a \n if required.
