### PR TITLE
Add .scss (Sassy CSS) extension to isCSS()

### DIFF
--- a/scripts/run.js
+++ b/scripts/run.js
@@ -100,6 +100,7 @@
   function isCSS(path, data) {
     return path.match(/\.css$/) ||
       path.match(/\.sass$/) ||
+      path.match(/\.scss$/) ||
       path.match(/\.less$/);
   }
 


### PR DESCRIPTION
It seems like several people (myself included) would like to prettify SCSS files (Issues #82 & #85). Since the prettifier already handles CSS, and SCSS is just a superset of CSS3, it should be able to handle SCSS syntax quite well.
