### PR TITLE
Added the ability for users to specify their own allowed file extensions...

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -9,11 +9,13 @@
     "max_preserve_newlines": 10,
     "preserve_newlines": true,
     "unformatted": ["a", "sub", "sup", "b", "i", "u"],
-    "wrap_line_length": 0
-  },
+    "wrap_line_length": 0,
+    "allowed_file_extensions": ["html", "shtml", "xml", "xhtml"]
+},
   "css": {
     "indent_char": " ",
-    "indent_size": 4
+    "indent_size": 4,
+    "allowed_file_extensions": ["css", "scss", "sass", "less"]
   },
   "js": {
     "brace_style": "collapse", // "expand", "end-expand", "expand-strict"
@@ -32,6 +34,7 @@
     "space_before_conditional": true,
     "space_in_paren": false,
     "unescape_strings": false,
-    "wrap_line_length": 0
+    "wrap_line_length": 0,
+    "allowed_file_extensions": ["js", "json", "jshintrc", "jsbeautifyrc"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ A few persistent options are always applied from a `.jsbeautifyrc` file located 
 * `Ctrl+Shift+P` or `Cmd+Shift+P` in Linux/Windows/OS X
 * type `htmlprettify`, select `Set Prettify Preferences`
 
-To add different file extensions (like jsp/gsp/php) edit `scripts/run.js`.
+To add different file extensions use `allowed_file_extensions` in the `.jsbeautifyrc` file in your home folder:
+```javascript
+{
+  "html": {
+    "allowed_file_extensions": ["html", "shtml", "aspx", "master", "xml", "xhtml"]
+  }
+  "css": {
+    "allowed_file_extensions": ["css", "scss", "sass", "less"]
+  }
+  "js": {
+    "allowed_file_extensions": ["js", "json", "jshintrc", "jsbeautifyrc"]
+  }
+}
+```
 
 Thank you!

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -91,25 +91,49 @@
   }
 
   function isHTML(path, data) {
-    return path.match(/\.html?$/) ||
-      path.match(/\.xhtml?$/) ||
-      path.match(/\.xml$/) ||
-      (path == "?" && data.match(/^\s*</)); // First non-whitespace character is &lt;
+    var typeIsAllowed = false;
+
+    // log(options["html"]["allowed_file_extensions"])
+    var maxIndex = options["html"]["allowed_file_extensions"].length;
+    for (var i=0; i<maxIndex; i++) {
+      if (!typeIsAllowed) {
+        typeIsAllowed = path.match(new RegExp("\\." + options["html"]["allowed_file_extensions"][i] + "?$"));
+      }
+    }
+     if (!typeIsAllowed && path =="?") { // If file unsaved, check if first non-whitespace character is &lt;
+      typeIsAllowed = data.match(/^\s*</);
+     }
+
+     return typeIsAllowed;
   }
 
   function isCSS(path, data) {
-    return path.match(/\.css$/) ||
-      path.match(/\.sass$/) ||
-      path.match(/\.less$/);
+    var typeIsAllowed = false;
+
+    // log(options["html"]["allowed_file_extensions"])
+    var maxIndex = options["css"]["allowed_file_extensions"].length;
+    for (var i=0; i<maxIndex; i++) {
+      if (!typeIsAllowed) {
+        typeIsAllowed = path.match(new RegExp("\\." + options["css"]["allowed_file_extensions"][i] + "?$"));
+      }
+    }
+     return typeIsAllowed;
   }
 
   function isJS(path, data) {
-    return path.match(/\.jsm?$/) ||
-      path.match(/\.json$/) ||
-      path.match(/\.jshintrc$/) ||
-      path.match(/\.jsbeautifyrc$/) ||
-      path.match(/\.sublime-/) ||
-      (path == "?" && !data.match(/^\s*</)); // First non-whitespace character is not &lt;
+    var typeIsAllowed = false;
+
+    // log(options["html"]["allowed_file_extensions"])
+    var maxIndex = options["js"]["allowed_file_extensions"].length;
+    for (var i=0; i<maxIndex; i++) {
+      if (!typeIsAllowed) {
+        typeIsAllowed = path.match(new RegExp("\\." + options["js"]["allowed_file_extensions"][i] + "?$"));
+      }
+    }
+     if (!typeIsAllowed && path =="?") { // If file unsaved, check if first non-whitespace character is not &lt;
+      typeIsAllowed = !data.match(/^\s*</);
+     }
+     return typeIsAllowed;
   }
 
   // Read the source file and, when complete, beautify the code.


### PR DESCRIPTION
Hi victorproof,

I see that a lot of your feature requests are for adding file extensions, and if the changes are in run.js, they get over-written by future versions of the plug in. By moving this option into .jsbeautifyrc, the changes can be saved through future updates of your plug in, and users can get directly to the options from Sublime Preferences.

It's not quite as versatile as your regular expressions ("sublime-*") but users can get around this by simply specifying the extensions they want supported without using wildcards.

I updated the documentation to mention this change, as well.
