### PR TITLE
Prettify Selection Only

### DIFF
--- a/HTMLPrettify.py
+++ b/HTMLPrettify.py
@@ -118,9 +118,10 @@ Alernatively, Node.js may not have been found. Please specify the location.'''
     self.view.set_viewport_position(previous_position, False)
 
     self.view.sel().clear()
-    if TextSelection.empty():
-      for a, b in previous_selection:
-        self.view.sel().add(sublime.Region(a, b))
+    for a, b in previous_selection:
+      if not TextSelection.empty():
+        a = b
+      self.view.sel().add(sublime.Region(a, b))
 
 class PreSaveFormatListner(sublime_plugin.EventListener):
   def on_pre_save(self, view):


### PR DESCRIPTION
I had a few funky problems with Django template tags, so I thought I would help in making a selection-only alternative to the prettify script.  Working for me.  Interested to know if there are any backwards compatibility issues.

resolves victorporof/Sublime-HTMLPrettify#67
and resolves victorporof/Sublime-HTMLPrettify#37
