### PR TITLE
Adds svg (a subset of XML) to allowed extensions

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -2,7 +2,7 @@
   // Details: https://github.com/victorporof/Sublime-HTMLPrettify#using-your-own-jsbeautifyrc-options
   // Documentation: https://github.com/einars/js-beautify/
   "html": {
-    "allowed_file_extensions": ["htm", "html", "xhtml", "shtml", "xml"],
+    "allowed_file_extensions": ["htm", "html", "xhtml", "shtml", "xml", "svg"],
     "brace_style": "collapse", // "expand", "end-expand", "expand-strict"
     "indent_char": " ",
     "indent_scripts": "keep", // "separate", "normal"


### PR DESCRIPTION
The HTML formatter works quite well with SVG files.

Fixes #120
