### PR TITLE
Subprocess, Logging Tweaks

### DIFF
--- a/HTMLPrettify.py
+++ b/HTMLPrettify.py
@@ -39,7 +39,8 @@ class HtmlprettifyCommand(sublime_plugin.TextCommand):
     os.remove(temp_file_path)
 
     # Dump any diagnostics and get the output after the identification marker.
-    print(self.get_output_diagnostics(output))
+    if PluginUtils.get_pref('print_diagnostics'):
+      print(self.get_output_diagnostics(output))
     output = self.get_output_data(output)
 
     # If the prettified text length is nil, the current syntax isn't supported.
@@ -205,4 +206,4 @@ class PluginUtils:
     else:
       # Handle all OS in Python 3.
       run = '"' + '" "'.join(cmd) + '"'
-      return subprocess.check_output(run, stderr=subprocess.STDOUT, shell=True)
+      return subprocess.check_output(run, stderr=subprocess.STDOUT, shell=True, env=os.environ)

--- a/HTMLPrettify.sublime-settings
+++ b/HTMLPrettify.sublime-settings
@@ -8,5 +8,6 @@
     "osx": "/usr/local/bin/node"
   },
   "format_on_save": false,
-  "format_selection_only": true
+  "format_selection_only": true,
+  "print_diagnostics": true
 }


### PR DESCRIPTION
- Explicitly pass `os.environ` to `subprocess.check_output()`. Fixes
  bug in which the subprocess failed to inherit the package's environment,
  so `PluginUtils`' checks could find the Node binary but the new
  process could not.
- Add `print_diagnostics` setting, allowing the user to suppress verbose
  logging of JSBeautify's configuration.
