### PR TITLE
let CSS support add newline between rules

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -20,7 +20,8 @@
     "indent_char": " ",
     "indent_size": 4,
     "selector_separator": " ",
-    "selector_separator_newline": false
+    "selector_separator_newline": false,
+    "newline_between_rules":true
   },
   "js": {
     "allowed_file_extensions": ["js", "json", "jshintrc", "jsbeautifyrc"],

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ These are the default options used by this plugin:
     "indent_char": " ",
     "indent_size": 4,
     "selector_separator": " ",
-    "selector_separator_newline": false
+    "selector_separator_newline": false,
+    "newline_between_rules": true
   },
   "js": {
     "allowed_file_extensions": ["js", "json", "jshintrc", "jsbeautifyrc"],

--- a/scripts/node_modules/js-beautify/js/lib/beautify-css.js
+++ b/scripts/node_modules/js-beautify/js/lib/beautify-css.js
@@ -65,6 +65,7 @@
         var indentCharacter = options.indent_char || ' ';
         var selectorSeparatorNewline = (options.selector_separator_newline === undefined) ? true : options.selector_separator_newline;
         var end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
+        var newline_between_rules = (options.newline_between_rules === undefined) ? true : options.newline_between_rules;
 
         // compatibility
         if (typeof indentSize === "string") {
@@ -215,7 +216,7 @@
             }
         };
 
-        
+
         var output = [];
         if (basebaseIndentString) {
             output.push(basebaseIndentString);
@@ -296,6 +297,9 @@
             } else if (ch === '}') {
                 outdent();
                 print["}"](ch);
+                if (newline_between_rules) {
+                    output.push('\n');
+                }
                 insideRule = false;
                 if (nestedLevel) {
                     nestedLevel--;


### PR DESCRIPTION
According to Google's CSS guide, it may be useful to support adding
newline between rules, so I try to make it.

If I did something wrong, please let me know and I will fix it as soon
as possible.

By the way, this plugin is very useful, all of our front-end developers
now use it.

Thanks.
