### PR TITLE
Reading the STDOUT (on Windows at least) caused an extra linebreak to be...

### DIFF
--- a/HTMLPrettify.py
+++ b/HTMLPrettify.py
@@ -209,4 +209,8 @@ class PluginUtils:
     else:
       # Handle all OS in Python 3.
       run = '"' + '" "'.join(cmd) + '"'
-      return subprocess.check_output(run, stderr=subprocess.STDOUT, shell=True, env=os.environ)
+      res = subprocess.check_output(run, stderr=subprocess.STDOUT, shell=True, env=os.environ)
+      if len(res) > 0:
+        res = res[:len(res)-1]
+
+      return res


### PR DESCRIPTION
... added to the buffer. Most likely because communication between the Python script and the JS script is done via "console.log".

This change removes the last character, working around the issue.
