### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For example, on Linux the path could be in `/home/<user>/.nvm/<node version>/bin
 
 On Windows, the absolute path to node.exe *must* use forward slashes.
 
-### Be very careful on Linux!
+### Be very careful on Debian!
 Depending on your distribution and default package sources, `apt-get install node` (for example) *will not* install node.js, contrary to all human common sense and popular belief. You want `nodejs` instead. Best thing is to make it yourself from http://nodejs.org/#download.
 
 ## Beautify on Save


### PR DESCRIPTION
Since this is a typical issue for Debian (Ubuntu & Friends) and their package naming tangle. Not for RHEL (CentOS, Fedora etc.).