### PR TITLE
Fix trailing newline problem with end_with_newline

### DIFF
--- a/HTMLPrettify.py
+++ b/HTMLPrettify.py
@@ -112,7 +112,7 @@ class HtmlprettifyCommand(sublime_plugin.TextCommand):
 
   def get_output_data(self, output):
     index = output.find(OUTPUT_VALID)
-    return output[index + len(OUTPUT_VALID) + 1:].decode("utf-8")
+    return output[index + len(OUTPUT_VALID) + 1:-1].decode("utf-8")
 
   def refold_folded_regions(self, folded_regions_content, entire_file_contents):
     self.view.unfold(sublime.Region(0, len(entire_file_contents)))


### PR DESCRIPTION
This fixes #210. Tested with HTML, CSS and JS. Works fine for me.