### PR TITLE
change "brace_style" default option to "collapse-preserve-inline"

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -31,7 +31,15 @@
   },
   "js": {
     "allowed_file_extensions": ["js", "json", "jshintrc", "jsbeautifyrc"],
-    "brace_style": "collapse", // [collapse|expand|end-expand|none] Put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line, or attempt to keep them where they are
+
+    // Set brace_style
+    //  collapse: (old default) Put braces on the same line as control statements
+    //  collapse-preserve-inline: (new default) Same as collapse but better support for ES6 destructuring and other features. https://github.com/victorporof/Sublime-HTMLPrettify/issues/231
+    //  expand: Put braces on own line (Allman / ANSI style)
+    //  end-expand: Put end braces on own line
+    //  none: Keep them where they are
+    "brace_style": "collapse-preserve-inline",
+
     "break_chained_methods": false, // Break chained method calls across subsequent lines
     "e4x": false, // Pass E4X xml literals through untouched
     "end_with_newline": false, // End output with newline


### PR DESCRIPTION
A new option was added in jsbeautifier (which has already been updated to 1.6.2 here) "collapse-preserve-inline" which is in most ways same as the old default "collapse" but it has better support for the newer ES6 features.

This changes the old default from "collapse" to "collapse-preserve-inline"

#231 