### PR TITLE
Make the file extension check ignore case

### DIFF
--- a/scripts/run.js
+++ b/scripts/run.js
@@ -121,7 +121,7 @@ function isTypeAllowed(type, path) {
     "js": ["js", "json", "jshintrc", "jsbeautifyrc"]
   }[type];
   for (var i = 0, len = allowedFileExtensions.length; i < len; i++) {
-    if (path.match(new RegExp("\\." + allowedFileExtensions[i] + "$"))) {
+    if (path.match(new RegExp("\\." + allowedFileExtensions[i] + "$", "i"))) {
       return true;
     }
   }


### PR DESCRIPTION
Today, if the file extension is XML/Html rather than xml/html, the format logic could not be applied.  User will have to go to the '. jsbeautifyrc' file to manually add the capitalized extension. And they might be a lot of low/uppercase combinations. 

This change adds an "i" to the regexp so that case would not matter in the 'isTypeAllowed()' function. This way it will accept file extensions ignoring cases. 

Thanks!