### PR TITLE
Check personal Sublime settings folder for a jsbeautifyrc

### DIFF
--- a/HTMLPrettify.py
+++ b/HTMLPrettify.py
@@ -11,6 +11,7 @@ except ImportError:
   pass
 
 PLUGIN_FOLDER = os.path.dirname(os.path.realpath(__file__))
+USER_FOLDER = os.path.join(sublime.packages_path(), 'User')
 RC_FILE = ".jsbeautifyrc"
 SETTINGS_FILE = "HTMLPrettify.sublime-settings"
 KEYMAP_FILE = "Default ($PLATFORM).sublime-keymap"
@@ -83,7 +84,7 @@ class HtmlprettifyCommand(sublime_plugin.TextCommand):
       node_path = PluginUtils.get_node_path()
       script_path = PLUGIN_FOLDER + "/scripts/run.js"
       file_path = self.view.file_name()
-      cmd = [node_path, script_path, temp_file_path, file_path or "?"]
+      cmd = [node_path, script_path, temp_file_path, file_path or "?", USER_FOLDER]
       output = PluginUtils.get_output(cmd)
 
       # Make sure the correct/expected output is retrieved.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,14 @@ var a = 1;
 ```
 
 ## Using your own .jsbeautifyrc options
-The plugin looks for a `.jsbeautifyrc` file in the same directory as the source file you're prettifying (or any directory above if it doesn't exist, or in your home folder if everything else fails) and uses those options along the default ones. [Here](https://github.com/einars/js-beautify/blob/master/js/config/defaults.json)'s an example of how it can look like.
+The plugin looks for a `.jsbeautifyrc` file in the following directories:
+
+1. The same directory as the source file you're prettifying.
+2. The source file's parent directories.
+3. Your home folder.
+4. Your personal Sublime settings folder.
+
+When one is found, it stops searching, and it uses those options along with the default ones. [Here](https://github.com/einars/js-beautify/blob/master/js/config/defaults.json)'s an example of how it can look like.
 
 These are the default options used by this plugin:
 ```javascript

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -17,6 +17,7 @@ path.sep = path.sep || "/";
 // The source file to be prettified, original source's path and some options.
 var tempPath = process.argv[2] || "";
 var filePath = process.argv[3] || "";
+var userFolder = process.argv[4] || "";
 var pluginFolder = path.dirname(__dirname);
 var sourceFolder = path.dirname(filePath);
 var options = { html: {}, css: {}, js: {} };
@@ -37,11 +38,13 @@ var pathsToLook = sourceFolderParts.map(function(value, key) {
   return sourceFolderParts.slice(0, key + 1).join(path.sep);
 });
 
-// Start with the current directory first, end with the user's home folder.
+// Start with the current directory first, then with the user's home folder, and
+// end with the user's personal sublime settings folder.
 pathsToLook.reverse();
 pathsToLook.push(getUserHome());
+pathsToLook.push(userFolder);
 
-pathsToLook.some(function(pathToLook) {
+pathsToLook.filter(Boolean).some(function(pathToLook) {
   if (fs.existsSync(jsbeautifyrcPath = path.join(pathToLook, ".jsbeautifyrc"))) {
     setOptions(jsbeautifyrcPath, options);
     return true;


### PR DESCRIPTION
For those that only have a `.jsbeautifyrc` for Sublime-HTMLPrettify, it makes sense to keep it with the rest of the personal Sublime stuff. In the case of a Mac this location is `~/Library/Application Support/Sublime Text 3/Packages/User`.