### PR TITLE
added option to use syntax for filetype

### DIFF
--- a/HTMLPrettify.py
+++ b/HTMLPrettify.py
@@ -84,7 +84,9 @@ class HtmlprettifyCommand(sublime_plugin.TextCommand):
       node_path = PluginUtils.get_node_path()
       script_path = PLUGIN_FOLDER + "/scripts/run.js"
       file_path = self.view.file_name()
-      cmd = [node_path, script_path, temp_file_path, file_path or "?", USER_FOLDER]
+      if PluginUtils.get_pref("use_syntax_for_filetype"):
+        syntax = self.view.settings().get("syntax")
+      cmd = [node_path, script_path, temp_file_path, file_path or "?", USER_FOLDER, syntax]
       output = PluginUtils.get_output(cmd)
 
       # Make sure the correct/expected output is retrieved.
@@ -211,3 +213,13 @@ class PluginUtils:
       # Handle all OS in Python 3.
       run = '"' + '" "'.join(cmd) + '"'
       return subprocess.check_output(run, stderr=subprocess.STDOUT, shell=True, env=os.environ)
+
+  @staticmethod
+  def tmp_file():
+      '''
+          Create a temp file and return the filepath to it.
+          Caller is responsible for clean up
+      '''
+      fd, filepath = tempfile.mkstemp(prefix='html_prettify_')
+      os.close(fd)
+      return filepath

--- a/HTMLPrettify.sublime-settings
+++ b/HTMLPrettify.sublime-settings
@@ -15,5 +15,8 @@
   "format_selection_only": true,
 
   // Log the settings passed to the prettifier from `.jsbeautifyrc`.
-  "print_diagnostics": true
+  "print_diagnostics": true,
+
+  // Use selected file syntax to determine file type
+  "use_syntax_for_filetype": true
 }

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -18,6 +18,7 @@ path.sep = path.sep || "/";
 var tempPath = process.argv[2] || "";
 var filePath = process.argv[3] || "";
 var userFolder = process.argv[4] || "";
+var syntax = process.argv[5] || "";
 var pluginFolder = path.dirname(__dirname);
 var sourceFolder = path.dirname(filePath);
 var options = { html: {}, css: {}, js: {} };
@@ -134,6 +135,7 @@ function isTypeAllowed(type, path) {
 }
 
 function isCSS(path, data) {
+  if (syntax) return syntax.toLowerCase().includes('css');
   // If file unsaved, there's no good way to determine whether or not it's
   // CSS based on the file contents.
   if (path == "?") {
@@ -143,6 +145,7 @@ function isCSS(path, data) {
 }
 
 function isHTML(path, data) {
+  if (syntax) return syntax.toLowerCase().includes('html');
   // If file unsaved, check if first non-whitespace character is &lt;
   if (path == "?") {
     return data.match(/^\s*</);
@@ -151,6 +154,7 @@ function isHTML(path, data) {
 }
 
 function isJS(path, data) {
+  if (syntax) return syntax.toLowerCase().includes('javascript');
   // If file unsaved, check if first non-whitespace character is NOT &lt;
   if (path == "?") {
     return !data.match(/^\s*</);


### PR DESCRIPTION
closes #365
- added setting to `HTMLPrettify.sublime-settings`
- added getter to `HTMLPrettify.py` and updated `cmd` arguments
- added checks to `run.js` to compare syntax string to `css`, `html`,
and `javascript` as appropriate