### PR TITLE
recognize unsaved files with an allowed syntax chosen

### DIFF
--- a/build/js-transpiled/utils/fileUtils.js
+++ b/build/js-transpiled/utils/fileUtils.js
@@ -127,18 +127,10 @@ var hasAllowedFileSyntax = function hasAllowedFileSyntax(expectedType, fileSynta
 };
 
 var isCSS = exports.isCSS = function isCSS() {
-  // If file unsaved, there's no good way to determine whether or not it's
-  // CSS based on the file contents, so just bail.
-  if (_constants.ORIGINAL_FILE_PATH === '?') {
-    return false;
-  }
   if (isDisallowedFilePattern('css', _constants.ORIGINAL_FILE_PATH)) {
     return false;
   }
   var allowedExtension = hasAllowedFileExtension('css', _constants.ORIGINAL_FILE_PATH);
-  if (_constants.EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   var allowedSyntax = hasAllowedFileSyntax('css', _constants.EDITOR_FILE_SYNTAX);
   return allowedSyntax || allowedExtension;
 };
@@ -152,26 +144,15 @@ var isHTML = exports.isHTML = function isHTML(bufferContents) {
     return false;
   }
   var allowedExtension = hasAllowedFileExtension('html', _constants.ORIGINAL_FILE_PATH);
-  if (_constants.EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   var allowedSyntax = hasAllowedFileSyntax('html', _constants.EDITOR_FILE_SYNTAX);
   return allowedSyntax || allowedExtension;
 };
 
 var isJSON = exports.isJSON = function isJSON() {
-  // If file unsaved, there's no good way to determine whether or not it's
-  // JSON based on the file contents, so just bail.
-  if (_constants.ORIGINAL_FILE_PATH === '?') {
-    return false;
-  }
   if (isDisallowedFilePattern('json', _constants.ORIGINAL_FILE_PATH)) {
     return false;
   }
   var allowedExtension = hasAllowedFileExtension('json', _constants.ORIGINAL_FILE_PATH);
-  if (_constants.EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   var allowedSyntax = hasAllowedFileSyntax('json', _constants.EDITOR_FILE_SYNTAX);
   return allowedSyntax || allowedExtension;
 };
@@ -185,9 +166,6 @@ var isJS = exports.isJS = function isJS(bufferContents) {
     return false;
   }
   var allowedExtension = hasAllowedFileExtension('js', _constants.ORIGINAL_FILE_PATH);
-  if (_constants.EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   var allowedSyntax = hasAllowedFileSyntax('js', _constants.EDITOR_FILE_SYNTAX);
   return allowedSyntax || allowedExtension;
 };


### PR DESCRIPTION
Currently, unsaved files are unconditionally skipped, even if they have a syntax assigned in Sublime Text. This change allows these files to be recognized.