### PR TITLE
recognize unsaved files with syntax chosen & add JSON text match

### DIFF
--- a/build/js-transpiled/main.js
+++ b/build/js-transpiled/main.js
@@ -94,7 +94,7 @@ var main = function () {
               stdio.beginPrettifiedCode();
               stdio.out(beautify.html(fileContents, finalConfig.html));
               stdio.endPrettifiedCode();
-            } else if ((0, _fileUtils.isJSON)()) {
+            } else if ((0, _fileUtils.isJSON)(fileContents)) {
               stdio.info('Attempting to prettify what seems to be a JSON file.');
               stdio.endDiagnostics();
               stdio.beginPrettifiedCode();

--- a/build/js-transpiled/utils/fileUtils.js
+++ b/build/js-transpiled/utils/fileUtils.js
@@ -127,69 +127,51 @@ var hasAllowedFileSyntax = function hasAllowedFileSyntax(expectedType, fileSynta
 };
 
 var isCSS = exports.isCSS = function isCSS() {
-  // If file unsaved, there's no good way to determine whether or not it's
-  // CSS based on the file contents, so just bail.
-  if (_constants.ORIGINAL_FILE_PATH === '?') {
-    return false;
-  }
   if (isDisallowedFilePattern('css', _constants.ORIGINAL_FILE_PATH)) {
     return false;
   }
   var allowedExtension = hasAllowedFileExtension('css', _constants.ORIGINAL_FILE_PATH);
-  if (_constants.EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   var allowedSyntax = hasAllowedFileSyntax('css', _constants.EDITOR_FILE_SYNTAX);
   return allowedSyntax || allowedExtension;
 };
 
 var isHTML = exports.isHTML = function isHTML(bufferContents) {
-  // If file unsaved, check if first non-whitespace character is &lt;
-  if (_constants.ORIGINAL_FILE_PATH === '?') {
-    return bufferContents.match(/^\s*</);
-  }
   if (isDisallowedFilePattern('html', _constants.ORIGINAL_FILE_PATH)) {
     return false;
   }
   var allowedExtension = hasAllowedFileExtension('html', _constants.ORIGINAL_FILE_PATH);
-  if (_constants.EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   var allowedSyntax = hasAllowedFileSyntax('html', _constants.EDITOR_FILE_SYNTAX);
-  return allowedSyntax || allowedExtension;
+  if (allowedSyntax || allowedExtension) {
+    return true;
+  }
+  // check if first non-whitespace character is &lt;
+  return bufferContents.match(/^\s*</);
 };
 
-var isJSON = exports.isJSON = function isJSON() {
-  // If file unsaved, there's no good way to determine whether or not it's
-  // JSON based on the file contents, so just bail.
-  if (_constants.ORIGINAL_FILE_PATH === '?') {
-    return false;
-  }
+var isJSON = exports.isJSON = function isJSON(bufferContents) {
   if (isDisallowedFilePattern('json', _constants.ORIGINAL_FILE_PATH)) {
     return false;
   }
   var allowedExtension = hasAllowedFileExtension('json', _constants.ORIGINAL_FILE_PATH);
-  if (_constants.EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   var allowedSyntax = hasAllowedFileSyntax('json', _constants.EDITOR_FILE_SYNTAX);
-  return allowedSyntax || allowedExtension;
+  if (allowedSyntax || allowedExtension) {
+    return true;
+  }
+  // check if first non-whitespace character is left curly brace
+  return bufferContents.match(/^\s*\{/);
 };
 
 var isJS = exports.isJS = function isJS(bufferContents) {
-  // If file unsaved, check if first non-whitespace character is NOT &lt;
-  if (_constants.ORIGINAL_FILE_PATH === '?') {
-    return !bufferContents.match(/^\s*</);
-  }
   if (isDisallowedFilePattern('js', _constants.ORIGINAL_FILE_PATH)) {
     return false;
   }
   var allowedExtension = hasAllowedFileExtension('js', _constants.ORIGINAL_FILE_PATH);
-  if (_constants.EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   var allowedSyntax = hasAllowedFileSyntax('js', _constants.EDITOR_FILE_SYNTAX);
-  return allowedSyntax || allowedExtension;
+  if (allowedSyntax || allowedExtension) {
+    return true;
+  }
+  // check if first non-whitespace character is NOT &lt;
+  return !bufferContents.match(/^\s*</);
 };
 
 // Checks if a file path matches a particular glob string.

--- a/build/js-transpiled/utils/fileUtils.js
+++ b/build/js-transpiled/utils/fileUtils.js
@@ -158,7 +158,7 @@ var isJSON = exports.isJSON = function isJSON(bufferContents) {
     return true;
   }
   // check if first non-whitespace character is left curly brace
-  return bufferContents.match(/^\s*\{/);
+  return bufferContents.match(/^\s*[\{\[]/);
 };
 
 var isJS = exports.isJS = function isJS(bufferContents) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -65,7 +65,7 @@ async function main() {
     stdio.beginPrettifiedCode();
     stdio.out(beautify.html(fileContents, finalConfig.html));
     stdio.endPrettifiedCode();
-  } else if (isJSON()) {
+  } else if (isJSON(fileContents)) {
     stdio.info('Attempting to prettify what seems to be a JSON file.');
     stdio.endDiagnostics();
     stdio.beginPrettifiedCode();

--- a/src/js/utils/fileUtils.js
+++ b/src/js/utils/fileUtils.js
@@ -76,7 +76,7 @@ export const isJSON = (bufferContents) => {
     return true;
   }
   // check if first non-whitespace character is left curly brace
-  return bufferContents.match(/^\s*\{/);
+  return bufferContents.match(/^\s*[\{\[]/);
 };
 
 export const isJS = (bufferContents) => {

--- a/src/js/utils/fileUtils.js
+++ b/src/js/utils/fileUtils.js
@@ -45,69 +45,51 @@ const hasAllowedFileSyntax = (expectedType, fileSyntax) => {
 };
 
 export const isCSS = () => {
-  // If file unsaved, there's no good way to determine whether or not it's
-  // CSS based on the file contents, so just bail.
-  if (ORIGINAL_FILE_PATH === '?') {
-    return false;
-  }
   if (isDisallowedFilePattern('css', ORIGINAL_FILE_PATH)) {
     return false;
   }
   const allowedExtension = hasAllowedFileExtension('css', ORIGINAL_FILE_PATH);
-  if (EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   const allowedSyntax = hasAllowedFileSyntax('css', EDITOR_FILE_SYNTAX);
   return allowedSyntax || allowedExtension;
 };
 
 export const isHTML = (bufferContents) => {
-  // If file unsaved, check if first non-whitespace character is &lt;
-  if (ORIGINAL_FILE_PATH === '?') {
-    return bufferContents.match(/^\s*</);
-  }
   if (isDisallowedFilePattern('html', ORIGINAL_FILE_PATH)) {
     return false;
   }
   const allowedExtension = hasAllowedFileExtension('html', ORIGINAL_FILE_PATH);
-  if (EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   const allowedSyntax = hasAllowedFileSyntax('html', EDITOR_FILE_SYNTAX);
-  return allowedSyntax || allowedExtension;
+  if (allowedSyntax || allowedExtension) {
+    return true;
+  }
+  // check if first non-whitespace character is &lt;
+  return bufferContents.match(/^\s*</);
 };
 
-export const isJSON = () => {
-  // If file unsaved, there's no good way to determine whether or not it's
-  // JSON based on the file contents, so just bail.
-  if (ORIGINAL_FILE_PATH === '?') {
-    return false;
-  }
+export const isJSON = (bufferContents) => {
   if (isDisallowedFilePattern('json', ORIGINAL_FILE_PATH)) {
     return false;
   }
   const allowedExtension = hasAllowedFileExtension('json', ORIGINAL_FILE_PATH);
-  if (EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   const allowedSyntax = hasAllowedFileSyntax('json', EDITOR_FILE_SYNTAX);
-  return allowedSyntax || allowedExtension;
+  if (allowedSyntax || allowedExtension) {
+    return true;
+  }
+  // check if first non-whitespace character is left curly brace
+  return bufferContents.match(/^\s*\{/);
 };
 
 export const isJS = (bufferContents) => {
-  // If file unsaved, check if first non-whitespace character is NOT &lt;
-  if (ORIGINAL_FILE_PATH === '?') {
-    return !bufferContents.match(/^\s*</);
-  }
   if (isDisallowedFilePattern('js', ORIGINAL_FILE_PATH)) {
     return false;
   }
   const allowedExtension = hasAllowedFileExtension('js', ORIGINAL_FILE_PATH);
-  if (EDITOR_FILE_SYNTAX === '?') {
-    return allowedExtension;
-  }
   const allowedSyntax = hasAllowedFileSyntax('js', EDITOR_FILE_SYNTAX);
-  return allowedSyntax || allowedExtension;
+  if (allowedSyntax || allowedExtension) {
+    return true;
+  }
+  // check if first non-whitespace character is NOT &lt;
+  return !bufferContents.match(/^\s*</);
 };
 
 // Checks if a file path matches a particular glob string.


### PR DESCRIPTION
Currently, unsaved files are unconditionally skipped, even if they have a syntax assigned in Sublime Text. This change allows these files to be recognized, and adds a check for "{" which usually matches a JSON file.