### PR TITLE
expand user in node.js path

### DIFF
--- a/src/py/utils/env_utils.py
+++ b/src/py/utils/env_utils.py
@@ -5,6 +5,7 @@
 
 import subprocess
 from os import environ, devnull
+from os.path import expanduser
 
 from .constants import PLATFORM
 from .window_utils import get_pref
@@ -36,7 +37,7 @@ class NodeSyntaxError(RuntimeError):
 def get_node_path():
     """Gets the node.js path specified in this plugin's settings file"""
     node = get_pref("node_path").get(PLATFORM)
-    return node
+    return expanduser(node)
 
 
 def run_command(args):


### PR DESCRIPTION
Hi @victorporof! I actually submitted this PR by accident, meant to merge it into my fork. Anyway, it's working for me on MacOS. It allows you to use a ~ in the path to node.js. I needed this because I share the same configuration across machines with different usernames. Let me know if you're interested in merging this and I can do some more testing on Windows and Linux.