### PR TITLE
Update package.json

### DIFF
--- a/build/js-transpiled/package.json
+++ b/build/js-transpiled/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@babel/runtime": "7.1.2",
+    "core-js": "2.5.7",
     "editorconfig-parser": "0.0.2",
     "fs-extra": "7.0.0",
     "is-glob": "4.0.0",


### PR DESCRIPTION
Added `"core-js": "2.5.7",` so it doesn't crash:
```
Node.js encountered a runtime error: internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module 'core-js/modules/es7.object.entries'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/Users/roblav96/Library/Application Support/Sublime Text 3/Packages/HTML-CSS-JS Prettify/build/js-transpiled/utils/configUtils.js:14:1)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
```
Adding `core-js` resolves the issue.