### PR TITLE
feat(main): reorganise it

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,98 +1,144 @@
-[{
-  "id": "tools",
-  "children": [{
-    "id": "htmlprettify_tools",
-    "caption": "HTML/CSS/JS Prettify",
-    "children": [{
-      "caption": "Prettify Code",
-      "command": "htmlprettify"
-    }, {
-      "caption": "-"
-    }, {
-      "caption": "Prettify Preferences - Default",
-      "command": "htmlprettify_set_prettify_prefs"
-    }, {
-      "caption": "Prettify Preferences - User",
-      "command": "htmlprettify_set_user_prettify_prefs"
-    }, {
-      "caption": "-"
-    }, {
-      "caption": "Plugin Options - Default",
-      "command": "htmlprettify_set_plugin_options"
-    }, {
-      "caption": "Plugin Options - User",
-      "command": "htmlprettify_set_user_plugin_options"
-    }, {
-      "caption": "-"
-    }, {
-      "caption": "Keyboard Shortcuts - Default",
-      "command": "htmlprettify_set_keyboard_shortcuts"
-    }, {
-      "caption": "Keyboard Shortcuts - User",
-      "command": "htmlprettify_set_user_keyboard_shortcuts"
-    }, {
-      "caption": "-"
-    }, {
-      "caption": "Set `node` Path",
-      "command": "htmlprettify_set_node_path"
-    }, {
-      "caption": "-"
-    }, {
-      "caption": "Help",
-      "command": "htmlprettify_open_help"
-    }, {
-      "caption": "File a bug",
-      "command": "htmlprettify_open_bug_file"
-    }, {
-      "caption": "What's new in v2.0?",
-      "command": "htmlprettify_open_release_notes"
-    }]
-  }]
-}, {
-  "id": "preferences",
-  "children": [{
-    "id": "package-settings",
-    "children": [{
-      "caption": "HTML/CSS/JS Prettify",
-      "children": [{
-        "caption": "Prettify Preferences - Default",
-        "command": "htmlprettify_set_prettify_prefs"
-      }, {
-        "caption": "Prettify Preferences - User",
-        "command": "htmlprettify_set_user_prettify_prefs"
-      }, {
-        "caption": "-"
-      }, {
-        "caption": "Plugin Options - Default",
-        "command": "htmlprettify_set_plugin_options"
-      }, {
-        "caption": "Plugin Options - User",
-        "command": "htmlprettify_set_user_plugin_options"
-      }, {
-        "caption": "-"
-      }, {
-        "caption": "Keyboard Shortcuts - Default",
-        "command": "htmlprettify_set_keyboard_shortcuts"
-      }, {
-        "caption": "Keyboard Shortcuts - User",
-        "command": "htmlprettify_set_user_keyboard_shortcuts"
-      }, {
-        "caption": "-"
-      }, {
-        "caption": "Set `node` Path",
-        "command": "htmlprettify_set_node_path"
-      }, {
-        "caption": "-"
-      }, {
-        "caption": "Help",
-        "command": "htmlprettify_open_help"
-      }, {
-        "caption": "File a bug",
-        "command": "htmlprettify_open_bug_file"
-      }, {
-        "caption": "What's new in v2.0?",
-        "command": "htmlprettify_open_release_notes"
-      }]
-    }]
-  }]
-}]
+[
+  {
+    "id": "tools",
+    "children": [
+      {
+        "id": "packages",
+        "children": [
+          {
+            "id": "htmlprettify_tools",
+            "caption": "HTML/CSS/JS Prettify",
+            "children": [
+              {
+                "caption": "Prettify Code",
+                "command": "htmlprettify"
+              },
+              {
+                "caption": "-"
+              },
+              {
+                "caption": "Prettify Preferences - Default",
+                "command": "htmlprettify_set_prettify_prefs"
+              },
+              {
+                "caption": "Prettify Preferences - User",
+                "command": "htmlprettify_set_user_prettify_prefs"
+              },
+              {
+                "caption": "-"
+              },
+              {
+                "caption": "Plugin Options - Default",
+                "command": "htmlprettify_set_plugin_options"
+              },
+              {
+                "caption": "Plugin Options - User",
+                "command": "htmlprettify_set_user_plugin_options"
+              },
+              {
+                "caption": "-"
+              },
+              {
+                "caption": "Keyboard Shortcuts - Default",
+                "command": "htmlprettify_set_keyboard_shortcuts"
+              },
+              {
+                "caption": "Keyboard Shortcuts - User",
+                "command": "htmlprettify_set_user_keyboard_shortcuts"
+              },
+              {
+                "caption": "-"
+              },
+              {
+                "caption": "Set `node` Path",
+                "command": "htmlprettify_set_node_path"
+              },
+              {
+                "caption": "-"
+              },
+              {
+                "caption": "Help",
+                "command": "htmlprettify_open_help"
+              },
+              {
+                "caption": "File a bug",
+                "command": "htmlprettify_open_bug_file"
+              },
+              {
+                "caption": "What's new in v2.0?",
+                "command": "htmlprettify_open_release_notes"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "preferences",
+    "children": [
+      {
+        "id": "package-settings",
+        "children": [
+          {
+            "caption": "HTML/CSS/JS Prettify",
+            "children": [
+              {
+                "caption": "Prettify Preferences - Default",
+                "command": "htmlprettify_set_prettify_prefs"
+              },
+              {
+                "caption": "Prettify Preferences - User",
+                "command": "htmlprettify_set_user_prettify_prefs"
+              },
+              {
+                "caption": "-"
+              },
+              {
+                "caption": "Plugin Options - Default",
+                "command": "htmlprettify_set_plugin_options"
+              },
+              {
+                "caption": "Plugin Options - User",
+                "command": "htmlprettify_set_user_plugin_options"
+              },
+              {
+                "caption": "-"
+              },
+              {
+                "caption": "Keyboard Shortcuts - Default",
+                "command": "htmlprettify_set_keyboard_shortcuts"
+              },
+              {
+                "caption": "Keyboard Shortcuts - User",
+                "command": "htmlprettify_set_user_keyboard_shortcuts"
+              },
+              {
+                "caption": "-"
+              },
+              {
+                "caption": "Set `node` Path",
+                "command": "htmlprettify_set_node_path"
+              },
+              {
+                "caption": "-"
+              },
+              {
+                "caption": "Help",
+                "command": "htmlprettify_open_help"
+              },
+              {
+                "caption": "File a bug",
+                "command": "htmlprettify_open_bug_file"
+              },
+              {
+                "caption": "What's new in v2.0?",
+                "command": "htmlprettify_open_release_notes"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
In Preferences, it's well organised as it's also in `package settings` menu, but for Tools, it was at the root, instead of `packages`.

Now it's fixed:

![image](https://user-images.githubusercontent.com/655838/79516035-7b224480-804a-11ea-90ee-6fc984cbd292.png)

(Sorry for the formatting, it was done by prettier).