### PR TITLE
Update get_pref() to allow settings inside Sublime project files

### DIFF
--- a/src/py/event_listeners.py
+++ b/src/py/event_listeners.py
@@ -12,26 +12,26 @@ from .utils.debounce_utils import debounce
 class HtmlprettifyEventListeners(EventListener):
     @staticmethod
     def on_pre_save(view):
-        if get_pref("format_on_save"):
+        if get_pref("format_on_save", view):
             view.run_command("htmlprettify")
 
     @staticmethod
     def on_load_async(view):
-        if get_pref("format_on_open"):
+        if get_pref("format_on_open", view):
             view.run_command("htmlprettify")
 
     @staticmethod
     def on_activated_async(view):
-        if get_pref("format_on_focus"):
+        if get_pref("format_on_focus", view):
             view.run_command("htmlprettify")
 
     @staticmethod
     def on_deactivated_async(view):
-        if get_pref("format_on_focus_lost"):
+        if get_pref("format_on_focus_lost", view):
             view.run_command("htmlprettify")
 
     @staticmethod
     @debounce(1)
     def on_modified_async(view):
-        if get_pref("format_while_editing"):
+        if get_pref("format_while_editing", view):
             view.run_command("htmlprettify")

--- a/src/py/main.py
+++ b/src/py/main.py
@@ -17,17 +17,17 @@ from .utils.script_utils import prettify_verbose
 
 
 def main(view, edit):
-    format_selection_only = get_pref("format_selection_only")
-    save_to_temp_file = get_pref("save_to_temp_file_before_prettifying")
-    global_file_rules = get_pref("global_file_rules")
-    respect_editorconfig_files = get_pref("respect_editorconfig_files")
+    format_selection_only = get_pref("format_selection_only", view)
+    save_to_temp_file = get_pref("save_to_temp_file_before_prettifying", view)
+    global_file_rules = get_pref("global_file_rules", view)
+    respect_editorconfig_files = get_pref("respect_editorconfig_files", view)
 
     editor_file_syntax = view.settings().get("syntax") if get_pref(
-        "use_editor_syntax") else "?"
+        "use_editor_syntax", view) else "?"
     editor_indent_size = view.settings().get("tab_size") if get_pref(
-        "use_editor_indentation") else "?"
+        "use_editor_indentation", view) else "?"
     editor_indent_with_tabs = view.settings().get("use_tab_stops") if get_pref(
-        "use_editor_indentation") else "?"
+        "use_editor_indentation, view") else "?"
 
     original_file_path = view.file_name() or "?"
     previous_viewport_position = view.viewport_position()

--- a/src/py/utils/window_utils.py
+++ b/src/py/utils/window_utils.py
@@ -11,9 +11,13 @@ from .paths import get_root_dir, get_user_dir
 from .file_utils import read_text_from_file, ensure_file
 
 
-def get_pref(key):
+def get_pref(key, view=None):
     """Retrieves the pref value under the given name key from the settings file"""
-    return load_settings(SETTINGS_FILENAME).get(key)
+
+    file_settings = load_settings(SETTINGS_FILENAME)
+    view_settings = view.settings() if view else {}
+
+    return view_settings.get("HTMLPrettify."+key, file_settings.get(key))
 
 
 def open_config_rc(window):


### PR DESCRIPTION
I use this plugin, but across an array of projects, some of which I want to be prettified on save, and others I don't. I use `.sublime-project` files and many related plugins (e.g. `isort`, `sublack`) allow settings entries in that file for per-project settings.

This PR brings that functionality to Sublime-HTMLPrettify, allowing settings in `.sublime-project` files (with a prefix).

For example if you want to update the `format_on_save` in a `.sublime-project` file you can add in:

```json
"settings":
{
	"HTMLPrettify.format_on_save": true
}
```
